### PR TITLE
Bug:53577 - Configure cloud-enablement templates to setup swap space

### DIFF
--- a/mlcluster-vpc.template
+++ b/mlcluster-vpc.template
@@ -747,6 +747,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -791,6 +794,10 @@ Resources:
             - !Ref LogSNS
             - |+
 
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
+            - |+
+
             - !If
               - UseVolumeEncryption
               - !Join
@@ -820,6 +827,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -864,6 +874,10 @@ Resources:
             - !Ref LogSNS
             - |+
 
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
+            - |+
+
             - !If
               - UseVolumeEncryption
               - !Join
@@ -893,6 +907,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -935,6 +952,10 @@ Resources:
 
             - MARKLOGIC_LOG_SNS=
             - !Ref LogSNS
+            - |+
+
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
             - |+
 
             - !If

--- a/mlcluster.template
+++ b/mlcluster.template
@@ -659,6 +659,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -703,6 +706,10 @@ Resources:
             - !Ref LogSNS
             - |+
 
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
+            - |+
+
             - !If
               - UseVolumeEncryption
               - !Join
@@ -732,6 +739,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -776,6 +786,10 @@ Resources:
             - !Ref LogSNS
             - |+
 
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
+            - |+
+
             - !If
               - UseVolumeEncryption
               - !Join
@@ -805,6 +819,9 @@ Resources:
       - InstanceSecurityGroup
     Properties:
       BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 40
         - DeviceName: /dev/sdf
           NoDevice: true
           Ebs: {}
@@ -847,6 +864,10 @@ Resources:
 
             - MARKLOGIC_LOG_SNS=
             - !Ref LogSNS
+            - |+
+
+            - MARKLOGIC_AWS_SWAP_SIZE=
+            - 32
             - |+
 
             - !If


### PR DESCRIPTION
Configure default root volume size (40GB) and swap size (32GB) through CF templates.