### PR TITLE
Add gp3 as an allowed value for the EBS Data volumes and make it the default

### DIFF
--- a/mlcluster.template
+++ b/mlcluster.template
@@ -101,7 +101,8 @@ Parameters:
     AllowedValues:
       - standard
       - gp2
-    Default: gp2
+      - gp3
+    Default: gp3
   VolumeEncryption:
     Description: Whether to enable volume encryption
     Type: String


### PR DESCRIPTION
gp3 EBS volumes are more performant and cheaper than gp2 volumes.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html